### PR TITLE
Remove shelf arrow repositioning

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "ecowaterqa",
   "name": "ecowater-theme",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "title": "Ecowater Theme",
   "description": "",
   "mustUpdateAt": "2019-10-24",

--- a/styles/css/vtex.shelf.css
+++ b/styles/css/vtex.shelf.css
@@ -26,10 +26,3 @@
   color: #183b56;
 }
 
-.arrowLeft {
-  left: -2rem;
-}
-
-.arrowRight {
-  right: -2rem;
-}


### PR DESCRIPTION
The fixed shelf makes this CSS obsolete, and makes it push the arrows out of the viewport.